### PR TITLE
chore: .mcp.json.example 追加と MCP セットアップ手順の文書化

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "docs": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["/path/to/docs-mcp-server/build/index.js"],
+      "env": {
+        "LOCAL_MODE": "true",
+        "PROJECT_ROOT": "/path/to/nestjs-bff",
+        "DOCS_BASE_PATH": "./docs"
+      }
+    }
+  }
+}

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -98,3 +98,31 @@ npm run start:dev
 
 `gen:all` 実行後に `tsc --noEmit` が失敗する場合、バックエンドの API が変更されています。
 `src/users/users.service.ts` などの呼び出し箇所を更新してください。
+
+## MCP サーバーセットアップ（オプション）
+
+Claude Code でプロジェクトドキュメントを参照可能にするには
+[docs-mcp-server](https://github.com/your-org/docs-mcp-server) のセットアップが必要です。
+
+### 前提条件
+
+- `docs-mcp-server` をクローン済みでビルド済みであること
+
+### 手順
+
+1. `.mcp.json.example` をコピーして `.mcp.json` を作成
+
+   ```bash
+   cp .mcp.json.example .mcp.json
+   ```
+
+2. `.mcp.json` を開き、以下の 2 か所を自環境の絶対パスに書き換える
+
+   | プレースホルダー | 置き換え例 |
+   |----------------|-----------|
+   | `/path/to/docs-mcp-server/build/index.js` | `/home/user/dev/docs-mcp-server/build/index.js` |
+   | `/path/to/nestjs-bff` | `/home/user/dev/nestjs-bff` |
+
+3. Claude Code を再起動（`.mcp.json` は起動時に読み込まれる）
+
+設定後、Claude Code から `docs` MCP ツールでドキュメント検索が可能になります。


### PR DESCRIPTION
## 概要

- `.mcp.json.example` を新規追加（プレースホルダーパス入り）
- `docs/setup.md` 末尾に MCP サーバーセットアップ手順を追記

新規クローン時でも MCP セットアップ方法を把握できるようにする。

## 変更内容

- `.mcp.json.example`: `docs-mcp-server` のパスをプレースホルダーで記載したサンプル設定
- `docs/setup.md`: トラブルシューティング後に「MCP サーバーセットアップ（オプション）」セクションを追加

## 確認事項

- [ ] `.mcp.json.example` が git 追跡対象であること
- [ ] `.mcp.json` が `.gitignore` により追跡されないままであること
- [ ] `docs/setup.md` の手順が読みやすいこと

Closes #3