### PR TITLE
chore: 既存lintエラーの一括修正 (issue #39)

### DIFF
--- a/src/app.module.spec.ts
+++ b/src/app.module.spec.ts
@@ -58,9 +58,11 @@ describe('ThrottlerGuard', () => {
 describe('CacheModule useFactory', () => {
   const mockConfig = (overrides: Record<string, unknown>) =>
     ({
-      get: jest.fn().mockImplementation((key: string, def: unknown) =>
-        key in overrides ? overrides[key] : def,
-      ),
+      get: jest
+        .fn()
+        .mockImplementation((key: string, def: unknown) =>
+          key in overrides ? overrides[key] : def,
+        ),
       getOrThrow: jest.fn().mockImplementation((key: string) => {
         if (key in overrides) return overrides[key];
         throw new Error(`Missing required config: ${key}`);
@@ -121,7 +123,9 @@ describe('CacheModule useFactory', () => {
 
   describe('インメモリ LRU ストア', () => {
     it('CACHE_MAX_ITEMS を指定した場合はその値を maxItems に使用する', () => {
-      const result = computeCacheStoreParams(mockConfig({ CACHE_MAX_ITEMS: 200 }));
+      const result = computeCacheStoreParams(
+        mockConfig({ CACHE_MAX_ITEMS: 200 }),
+      );
       expect(result.type).toBe('memory');
       if (result.type === 'memory') {
         expect(result.maxItems).toBe(200);

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,7 +22,9 @@ export type CacheStoreParams =
   | { type: 'redis'; ttlMs: number; redisOptions: object }
   | { type: 'memory'; ttlMs: number; maxItems: number };
 
-export function computeCacheStoreParams(config: ConfigService): CacheStoreParams {
+export function computeCacheStoreParams(
+  config: ConfigService,
+): CacheStoreParams {
   // CACHE_TTL=0 は Keyv では「TTL なし（永久）」になるため 1ms にフォールバック
   const rawTtl = Number(config.get('CACHE_TTL', 30));
   const ttlMs = rawTtl > 0 ? rawTtl * 1000 : 1;
@@ -67,8 +69,13 @@ export function computeCacheStoreParams(config: ConfigService): CacheStoreParams
                 }
               : undefined,
           serializers: {
-            req: (req) => ({ method: req.method, url: req.url }),
-            res: (res) => ({ statusCode: res.statusCode }),
+            req: (req: { method: string; url: string }) => ({
+              method: req.method,
+              url: req.url,
+            }),
+            res: (res: { statusCode: number }) => ({
+              statusCode: res.statusCode,
+            }),
           },
           autoLogging: {
             ignore: (req) =>
@@ -96,14 +103,20 @@ export function computeCacheStoreParams(config: ConfigService): CacheStoreParams
         if (params.type === 'redis') {
           return {
             stores: [
-              new Keyv({ store: new KeyvRedis(params.redisOptions), ttl: params.ttlMs }),
+              new Keyv({
+                store: new KeyvRedis(params.redisOptions),
+                ttl: params.ttlMs,
+              }),
             ],
           };
         }
         // in-memory: LRU でエントリ数上限を設けて OOM を防ぐ
         return {
           stores: [
-            new Keyv({ store: new LRUCache({ max: params.maxItems }), ttl: params.ttlMs }),
+            new Keyv({
+              store: new LRUCache({ max: params.maxItems }),
+              ttl: params.ttlMs,
+            }),
           ],
         };
       },

--- a/src/auth/guards/jwt-auth.guard.spec.ts
+++ b/src/auth/guards/jwt-auth.guard.spec.ts
@@ -44,10 +44,13 @@ describe('JwtAuthGuard', () => {
   describe('NODE_ENV が production かつ JWT_AUTH_ENABLED が true でないとき', () => {
     it('警告ログを出力する', () => {
       guard = buildGuard('false', 'production');
+      const privateGuard = guard as unknown as {
+        logger: { warn: (...args: unknown[]) => void };
+      };
       const warnSpy = jest
-        .spyOn((guard as any).logger, 'warn')
+        .spyOn(privateGuard.logger, 'warn')
         .mockImplementation(() => {});
-      guard.canActivate(mockExecutionContext());
+      void guard.canActivate(mockExecutionContext());
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('JWT_AUTH_ENABLED is not true in production'),
       );
@@ -71,7 +74,7 @@ describe('JwtAuthGuard', () => {
         .spyOn(AuthGuard('jwt').prototype, 'canActivate')
         .mockReturnValue(true);
       const ctx = mockExecutionContext();
-      guard.canActivate(ctx);
+      void guard.canActivate(ctx);
       expect(superSpy).toHaveBeenCalledWith(ctx);
       superSpy.mockRestore();
     });
@@ -94,9 +97,9 @@ describe('JwtAuthGuard', () => {
     });
 
     it('err が存在するとき UnauthorizedException をスローする', () => {
-      expect(() => guard.handleRequest(new Error('token expired'), null)).toThrow(
-        UnauthorizedException,
-      );
+      expect(() =>
+        guard.handleRequest(new Error('token expired'), null),
+      ).toThrow(UnauthorizedException);
     });
   });
 });

--- a/src/health/health.controller.spec.ts
+++ b/src/health/health.controller.spec.ts
@@ -52,6 +52,7 @@ describe('HealthController', () => {
   it('HealthCheckService.check を呼び出す', async () => {
     await controller.check();
 
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(healthCheckService.check).toHaveBeenCalledTimes(1);
   });
 
@@ -68,6 +69,7 @@ describe('HealthController', () => {
     const [indicators] = healthCheckService.check.mock.calls[0];
     await indicators[0]();
 
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(httpHealthIndicator.pingCheck).toHaveBeenCalledWith(
       'backend',
       'http://localhost:8080',

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,4 +45,4 @@ async function bootstrap() {
   await app.listen(process.env.PORT ?? 3000);
 }
 
-bootstrap();
+void bootstrap();

--- a/src/shared/filters/axios-exception.filter.spec.ts
+++ b/src/shared/filters/axios-exception.filter.spec.ts
@@ -136,6 +136,7 @@ describe('AxiosExceptionFilter', () => {
 
     filter.catch(exception, mockHost);
 
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.objectContaining({
         url: '/api/users',
@@ -156,7 +157,7 @@ describe('AxiosExceptionFilter', () => {
       expect.objectContaining({
         statusCode: 404,
         path: '/test',
-        timestamp: expect.any(String),
+        timestamp: expect.any(String) as unknown,
       }),
     );
   });

--- a/src/shared/filters/http-exception.filter.spec.ts
+++ b/src/shared/filters/http-exception.filter.spec.ts
@@ -47,7 +47,10 @@ describe('HttpExceptionFilter', () => {
   });
 
   it('401 のとき response.status(401) が呼ばれる', () => {
-    const exception = new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    const exception = new HttpException(
+      'Unauthorized',
+      HttpStatus.UNAUTHORIZED,
+    );
 
     filter.catch(exception, mockHost);
 
@@ -63,7 +66,10 @@ describe('HttpExceptionFilter', () => {
   });
 
   it('レスポンスに statusCode と path と timestamp が含まれる', () => {
-    const exception = new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    const exception = new HttpException(
+      'Unauthorized',
+      HttpStatus.UNAUTHORIZED,
+    );
 
     filter.catch(exception, mockHost);
 
@@ -71,13 +77,16 @@ describe('HttpExceptionFilter', () => {
       expect.objectContaining({
         statusCode: 401,
         path: '/test',
-        timestamp: expect.any(String),
+        timestamp: expect.any(String) as unknown,
       }),
     );
   });
 
   it('文字列レスポンスのとき message にそのまま使われる', () => {
-    const exception = new HttpException('Custom message', HttpStatus.BAD_REQUEST);
+    const exception = new HttpException(
+      'Custom message',
+      HttpStatus.BAD_REQUEST,
+    );
 
     filter.catch(exception, mockHost);
 
@@ -101,7 +110,7 @@ describe('HttpExceptionFilter', () => {
 
   it('オブジェクトレスポンスに message がないとき exception.message にフォールバックする', () => {
     const exception = new HttpException(
-      { error: 'Bad Request' } as any,
+      { error: 'Bad Request' } as Record<string, string>,
       HttpStatus.BAD_REQUEST,
     );
 
@@ -113,10 +122,14 @@ describe('HttpExceptionFilter', () => {
   });
 
   it('logger.warn が status と path を含むオブジェクト付きで呼ばれる', () => {
-    const exception = new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
+    const exception = new HttpException(
+      'Unauthorized',
+      HttpStatus.UNAUTHORIZED,
+    );
 
     filter.catch(exception, mockHost);
 
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(mockLogger.warn).toHaveBeenCalledWith(
       expect.objectContaining({ status: 401, path: '/test' }),
       expect.any(String),

--- a/src/shared/filters/http-exception.filter.ts
+++ b/src/shared/filters/http-exception.filter.ts
@@ -23,8 +23,8 @@ export class HttpExceptionFilter implements ExceptionFilter {
     const message =
       typeof exceptionResponse === 'string'
         ? exceptionResponse
-        : ((exceptionResponse as Record<string, unknown>).message as string) ??
-          exception.message;
+        : (((exceptionResponse as Record<string, unknown>).message as string) ??
+          exception.message);
 
     this.logger.warn(
       { status, path: request.url },

--- a/src/shared/interceptors/logging.interceptor.spec.ts
+++ b/src/shared/interceptors/logging.interceptor.spec.ts
@@ -121,6 +121,7 @@ describe('LoggingInterceptor', () => {
 
       await requestInterceptors[0](config);
 
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockLogger.info).toHaveBeenCalledWith(
         expect.objectContaining({
           direction: 'outbound',
@@ -143,6 +144,7 @@ describe('LoggingInterceptor', () => {
 
       await requestInterceptors[0](config);
 
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockLogger.info).toHaveBeenCalledWith(
         expect.objectContaining({ bodyLogged: true }),
         expect.any(String),
@@ -160,6 +162,7 @@ describe('LoggingInterceptor', () => {
 
       await requestInterceptors[0](config);
 
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockLogger.info).toHaveBeenCalledWith(
         expect.objectContaining({ bodyLogged: true }),
         expect.any(String),
@@ -177,6 +180,7 @@ describe('LoggingInterceptor', () => {
 
       await requestInterceptors[0](config);
 
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockLogger.info).toHaveBeenCalledWith(
         expect.objectContaining({ bodyLogged: false }),
         expect.any(String),
@@ -197,6 +201,7 @@ describe('LoggingInterceptor', () => {
 
       await responseInterceptors[0].fulfilled(res);
 
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(mockLogger.info).toHaveBeenCalledWith(
         expect.objectContaining({
           direction: 'inbound',

--- a/src/shared/interceptors/logging.interceptor.ts
+++ b/src/shared/interceptors/logging.interceptor.ts
@@ -45,7 +45,7 @@ export class LoggingInterceptor implements OnModuleInit {
         );
         return res;
       },
-      (err) => Promise.reject(err),
+      (err: Error) => Promise.reject(err),
     );
   }
 }

--- a/src/shared/interceptors/mock.interceptor.spec.ts
+++ b/src/shared/interceptors/mock.interceptor.spec.ts
@@ -4,7 +4,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import * as fs from 'fs';
 import { getLoggerToken } from 'nestjs-pino';
 
-import { MockInterceptor } from './mock.interceptor';
+import { MockError, MockInterceptor } from './mock.interceptor';
 
 describe('MockInterceptor', () => {
   let interceptor: MockInterceptor;
@@ -134,7 +134,7 @@ describe('MockInterceptor', () => {
 
     it('isMock エラーを正常レスポンスオブジェクトに変換する', async () => {
       const { rejected } = responseInterceptors[0];
-      const mockError = { isMock: true, data: [{ id: 1 }], status: 200 };
+      const mockError = new MockError([{ id: 1 }], 200);
 
       await expect(rejected(mockError)).resolves.toEqual({
         data: [{ id: 1 }],
@@ -149,7 +149,7 @@ describe('MockInterceptor', () => {
       await expect(rejected(error)).rejects.toThrow('Network Error');
     });
 
-    it('fulfilled レスポンスはそのまま返す', async () => {
+    it('fulfilled レスポンスはそのまま返す', () => {
       const { fulfilled } = responseInterceptors[0];
       const response = { data: { id: 1 }, status: 200 };
 

--- a/src/shared/interceptors/mock.interceptor.ts
+++ b/src/shared/interceptors/mock.interceptor.ts
@@ -6,10 +6,14 @@ import { Injectable, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectPinoLogger, PinoLogger } from 'nestjs-pino';
 
-interface MockError {
-  isMock: true;
-  data: unknown;
-  status: number;
+export class MockError extends Error {
+  readonly isMock = true as const;
+  constructor(
+    readonly data: unknown,
+    readonly status: number,
+  ) {
+    super('MockInterceptor: fixture response');
+  }
 }
 
 @Injectable()
@@ -52,11 +56,7 @@ export class MockInterceptor implements OnModuleInit {
           return config;
         }
         this.logger.debug(`Mock: ${method} ${url} → ${fixturePath}`);
-        return Promise.reject({
-          isMock: true,
-          data,
-          status: 200,
-        } satisfies MockError);
+        return Promise.reject(new MockError(data, 200));
       } catch {
         return config; // ファイルなし → 実リクエストへ
       }
@@ -64,10 +64,12 @@ export class MockInterceptor implements OnModuleInit {
 
     this.httpService.axiosRef.interceptors.response.use(
       (res) => res,
-      (err) => {
-        if (err?.isMock)
+      (err: unknown) => {
+        if (err instanceof MockError)
           return Promise.resolve({ data: err.data, status: err.status });
-        return Promise.reject(err);
+        return Promise.reject(
+          err instanceof Error ? err : new Error(String(err)),
+        );
       },
     );
 

--- a/src/shared/interceptors/user-aware-cache.interceptor.spec.ts
+++ b/src/shared/interceptors/user-aware-cache.interceptor.spec.ts
@@ -4,6 +4,10 @@ import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Reflector } from '@nestjs/core';
 import { UserAwareCacheInterceptor } from './user-aware-cache.interceptor';
 
+type InterceptorWithTrackBy = {
+  trackBy: (ctx: ExecutionContext) => string | undefined;
+};
+
 const createContext = (
   url: string,
   user?: { sub?: string },
@@ -40,7 +44,9 @@ describe('UserAwareCacheInterceptor', () => {
     it('認証済みユーザーは userId:url をキーとして返す', () => {
       const context = createContext('/api/users/42', { sub: 'user-1' });
 
-      const key = (interceptor as any).trackBy(context) as string | undefined;
+      const key = (interceptor as unknown as InterceptorWithTrackBy).trackBy(
+        context,
+      );
 
       expect(key).toBe('user-1:/api/users/42');
     });
@@ -48,7 +54,9 @@ describe('UserAwareCacheInterceptor', () => {
     it('user.sub が空の場合は undefined を返す（キャッシュしない）', () => {
       const context = createContext('/api/users', { sub: undefined });
 
-      const key = (interceptor as any).trackBy(context) as string | undefined;
+      const key = (interceptor as unknown as InterceptorWithTrackBy).trackBy(
+        context,
+      );
 
       expect(key).toBeUndefined();
     });
@@ -56,7 +64,9 @@ describe('UserAwareCacheInterceptor', () => {
     it('user が存在しない場合は undefined を返す（キャッシュしない）', () => {
       const context = createContext('/api/users');
 
-      const key = (interceptor as any).trackBy(context) as string | undefined;
+      const key = (interceptor as unknown as InterceptorWithTrackBy).trackBy(
+        context,
+      );
 
       expect(key).toBeUndefined();
     });
@@ -64,11 +74,16 @@ describe('UserAwareCacheInterceptor', () => {
     it('@Public() エンドポイントは未認証でも super.trackBy が呼ばれる', () => {
       reflector.getAllAndOverride.mockReturnValue(true);
       const superTrackBy = jest
-        .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(interceptor)), 'trackBy')
+        .spyOn(
+          Object.getPrototypeOf(Object.getPrototypeOf(interceptor)),
+          'trackBy',
+        )
         .mockReturnValue('/api/health');
 
       const context = createContext('/api/health');
-      const key = (interceptor as any).trackBy(context) as string | undefined;
+      const key = (interceptor as unknown as InterceptorWithTrackBy).trackBy(
+        context,
+      );
 
       expect(key).toBe('/api/health');
       superTrackBy.mockRestore();
@@ -78,7 +93,9 @@ describe('UserAwareCacheInterceptor', () => {
       reflector.getAllAndOverride.mockReturnValue(false);
       const context = createContext('/api/users');
 
-      const key = (interceptor as any).trackBy(context) as string | undefined;
+      const key = (interceptor as unknown as InterceptorWithTrackBy).trackBy(
+        context,
+      );
 
       expect(key).toBeUndefined();
     });
@@ -87,8 +104,12 @@ describe('UserAwareCacheInterceptor', () => {
       const ctx1 = createContext('/api/users', { sub: 'user-1' });
       const ctx2 = createContext('/api/users/42', { sub: 'user-1' });
 
-      const key1 = (interceptor as any).trackBy(ctx1) as string;
-      const key2 = (interceptor as any).trackBy(ctx2) as string;
+      const key1 = (interceptor as unknown as InterceptorWithTrackBy).trackBy(
+        ctx1,
+      );
+      const key2 = (interceptor as unknown as InterceptorWithTrackBy).trackBy(
+        ctx2,
+      );
 
       expect(key1).not.toBe(key2);
     });
@@ -97,8 +118,12 @@ describe('UserAwareCacheInterceptor', () => {
       const ctx1 = createContext('/api/users/42', { sub: 'user-1' });
       const ctx2 = createContext('/api/users/42', { sub: 'user-2' });
 
-      const key1 = (interceptor as any).trackBy(ctx1) as string;
-      const key2 = (interceptor as any).trackBy(ctx2) as string;
+      const key1 = (interceptor as unknown as InterceptorWithTrackBy).trackBy(
+        ctx1,
+      );
+      const key2 = (interceptor as unknown as InterceptorWithTrackBy).trackBy(
+        ctx2,
+      );
 
       expect(key1).not.toBe(key2);
     });

--- a/src/shared/interceptors/user-context.interceptor.spec.ts
+++ b/src/shared/interceptors/user-context.interceptor.spec.ts
@@ -21,7 +21,10 @@ describe('UserContextInterceptor', () => {
 
   it('req.user.sub が存在するとき AsyncLocalStorage の userId に格納される', (done) => {
     asyncLocalStorage.run({ correlationId: 'test-id' }, () => {
-      interceptor.intercept(makeContext({ sub: 'user-123' }), makeCallHandler());
+      interceptor.intercept(
+        makeContext({ sub: 'user-123' }),
+        makeCallHandler(),
+      );
       expect(asyncLocalStorage.getStore()?.userId).toBe('user-123');
       done();
     });
@@ -45,7 +48,10 @@ describe('UserContextInterceptor', () => {
 
   it('AsyncLocalStorage のストアが存在しないとき例外をスローしない', () => {
     expect(() => {
-      interceptor.intercept(makeContext({ sub: 'user-123' }), makeCallHandler());
+      interceptor.intercept(
+        makeContext({ sub: 'user-123' }),
+        makeCallHandler(),
+      );
     }).not.toThrow();
   });
 
@@ -56,7 +62,9 @@ describe('UserContextInterceptor', () => {
         makeCallHandler(),
       );
       result$.subscribe({
-        complete: () => done(),
+        complete: () => {
+          done();
+        },
       });
     });
   });

--- a/src/shared/interceptors/user-context.interceptor.ts
+++ b/src/shared/interceptors/user-context.interceptor.ts
@@ -10,7 +10,9 @@ import { asyncLocalStorage } from '../context/request-context';
 @Injectable()
 export class UserContextInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
-    const request = context.switchToHttp().getRequest<{ user?: { sub?: string } }>();
+    const request = context
+      .switchToHttp()
+      .getRequest<{ user?: { sub?: string } }>();
     const userId = request.user?.sub;
     if (userId) {
       const store = asyncLocalStorage.getStore();

--- a/src/shared/middleware/correlation-id.middleware.ts
+++ b/src/shared/middleware/correlation-id.middleware.ts
@@ -3,7 +3,7 @@ import { NextFunction, Request, Response } from 'express';
 import { asyncLocalStorage } from '../context/request-context';
 
 const CORRELATION_HEADER = 'x-request-id';
-const SAFE_ID_PATTERN = /^[\w\-]{1,128}$/;
+const SAFE_ID_PATTERN = /^[\w-]{1,128}$/;
 
 export function correlationIdMiddleware(
   req: Request,


### PR DESCRIPTION
## 概要

issue #39 で報告されていた既存の lint エラー（51件）をすべて修正します。

## 変更内容

| ルール | 対応内容 |
|--------|----------|
| `prefer-promise-reject-errors` | `LoggingInterceptor`: `err` を `Error` 型に明示。`MockInterceptor`: `MockError` をインターフェースからクラス（`extends Error`）に変更し `instanceof` チェックに統一 |
| `no-unsafe-*` | `app.module.ts`: serializer パラメータに型付与。`user-aware-cache.interceptor.spec.ts`: `InterceptorWithTrackBy` 型でキャスト。`jwt-auth.guard.spec.ts`: private フィールドを型付き中間変数経由でアクセス |
| `no-floating-promises` | `main.ts` の `bootstrap()` および spec の `canActivate()` 呼び出しに `void` 演算子を付与 |
| `unbound-method` | jest の `expect(mock.method).toHaveBeenCalled()` パターンに `eslint-disable-next-line` コメントを追加 |
| `no-unsafe-return` | `done()` の戻り値（`any`）を捨てるためブロック文 `{ done(); }` に変更 |
| `require-await` | 不要な `async` キーワードをテストから削除 |
| `no-useless-escape` | 正規表現 `[\w\-]` → `[\w-]` に修正 |

## 確認方法

```bash
npm run lint  # エラー 0 件
npm test      # 105 テスト全通過
```

## 関連 issue

Closes #39