### PR TITLE
feat: Generic Adapter パターン導入（Thin→Thick BFF への移行）

### DIFF
--- a/docs/bff-design-philosophy.md
+++ b/docs/bff-design-philosophy.md
@@ -156,9 +156,15 @@ Generated 側でフィールドが増えても `tsc` は MyUser 側を検出し�
 
 ## このリポジトリの立場
 
-このテンプレートは **Thin BFF** を採用している。
+このリポジトリは **Thin BFF を出発点として Thick BFF へ段階的に育てる**学習用リポジトリ。
+Generic Adapter パターンは実装済みで、以下のファイルで動作するコードを確認できる。
 
-理由は「テンプレートとして出発点にしやすいこと」と「型エラーの即時伝播による変更の検知性」を優先したため。
-Adapter 層が必要になった時点で `src/users/adapters/` を追加する形で拡張してほしい。
+| ファイル | 役割 |
+|---------|------|
+| `src/shared/adapters/generic-api.adapter.ts` | 汎用 Adapter クラス（CRUD を関数で注入） |
+| `src/users/adapters/user-backend.adapter.ts` | UsersModule 用 Adapter |
+| `src/products/adapters/product-backend.adapter.ts` | ProductsModule 用 Adapter |
 
-> Thick BFF に移行する際は、Adapter が生成型を返すよう設計することで型の断絶を防ぐことができる。
+Adapter は生成型（`UserDto`）をそのまま返すため、`tsc` がバックエンド変更を3層貫通して検出できる。
+
+> 新しいモジュールを追加する際は `src/users/adapters/` のパターンを参考にすること。

--- a/src/products/adapters/product-backend.adapter.ts
+++ b/src/products/adapters/product-backend.adapter.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { DefaultApi } from '../../generated/api';
-import { UserDto } from '../../generated/models';
 import { PRODUCT_SERVICE_API } from '../config/products-api.provider';
+import { ProductDto } from '../dto/product.dto';
 import { GenericApiAdapter } from '../../shared/adapters/generic-api.adapter';
 
 /**
@@ -10,11 +10,11 @@ import { GenericApiAdapter } from '../../shared/adapters/generic-api.adapter';
  * 実際の開発では ProductsApi に差し替え、getProducts() などを呼び出す。
  */
 @Injectable()
-export class ProductBackendAdapter extends GenericApiAdapter<UserDto> {
+export class ProductBackendAdapter extends GenericApiAdapter<ProductDto> {
   constructor(@Inject(PRODUCT_SERVICE_API) api: DefaultApi) {
     super(
-      () => api.getUsers(),
-      (id) => api.getUserById({ id }),
+      () => api.getUsers() as Promise<{ data: ProductDto[] }>,
+      (id) => api.getUserById({ id }) as Promise<{ data: ProductDto }>,
       // NOTE: 実際の ProductsApi では createProduct() などに差し替える
       (_body) => Promise.reject(new Error('create is not supported')),
     );

--- a/src/products/adapters/product-backend.adapter.ts
+++ b/src/products/adapters/product-backend.adapter.ts
@@ -1,0 +1,22 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { DefaultApi } from '../../generated/api';
+import { UserDto } from '../../generated/models';
+import { PRODUCT_SERVICE_API } from '../config/products-api.provider';
+import { GenericApiAdapter } from '../../shared/adapters/generic-api.adapter';
+
+/**
+ * ProductsModule 向けの Backend Adapter。
+ * NOTE: 現在は DefaultApi（UsersApi の代用）を使用しているが、
+ * 実際の開発では ProductsApi に差し替え、getProducts() などを呼び出す。
+ */
+@Injectable()
+export class ProductBackendAdapter extends GenericApiAdapter<UserDto> {
+  constructor(@Inject(PRODUCT_SERVICE_API) api: DefaultApi) {
+    super(
+      () => api.getUsers(),
+      (id) => api.getUserById({ id }),
+      // NOTE: 実際の ProductsApi では createProduct() などに差し替える
+      (_body) => Promise.reject(new Error('create is not supported')),
+    );
+  }
+}

--- a/src/products/dto/product.dto.ts
+++ b/src/products/dto/product.dto.ts
@@ -1,0 +1,7 @@
+/** Products バックエンドから返るデータ構造の暫定型定義。
+ * 実際の ProductsApi が生成されたら src/generated/models に差し替える。
+ */
+export interface ProductDto {
+  id?: number;
+  name: string;
+}

--- a/src/products/products.module.ts
+++ b/src/products/products.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
+import { ProductBackendAdapter } from './adapters/product-backend.adapter';
 import { ProductServiceApiProvider } from './config/products-api.provider';
 import { ProductsController } from './products.controller';
 import { ProductsService } from './products.service';
 
 @Module({
   controllers: [ProductsController],
-  providers: [ProductServiceApiProvider, ProductsService],
+  providers: [ProductServiceApiProvider, ProductBackendAdapter, ProductsService],
 })
 export class ProductsModule {}

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -1,21 +1,15 @@
-// NOTE: マルチバックエンド DI パターンのサンプル実装です。
-// PRODUCT_SERVICE_API トークンで注入された API クライアントが
-// PRODUCT_SERVICE_BASE_URL に向かって通信します。
-// 実際の開発では ProductsApi.getProducts() などを呼び出してください。
-import { Inject, Injectable } from '@nestjs/common';
+// NOTE: マルチバックエンド DI パターン + Generic Adapter パターンのサンプル実装です。
+import { Injectable } from '@nestjs/common';
 import { plainToInstance } from 'class-transformer';
-import { DefaultApi } from '../generated/api';
-import { PRODUCT_SERVICE_API } from './config/products-api.provider';
 import { ProductResponse } from './dto/product.response';
+import { ProductBackendAdapter } from './adapters/product-backend.adapter';
 
 @Injectable()
 export class ProductsService {
-  constructor(
-    @Inject(PRODUCT_SERVICE_API) private readonly api: DefaultApi,
-  ) {}
+  constructor(private readonly adapter: ProductBackendAdapter) {}
 
   async findAll(): Promise<ProductResponse[]> {
-    const { data } = await this.api.getUsers();
+    const data = await this.adapter.findAll();
     return plainToInstance(ProductResponse, data, {
       excludeExtraneousValues: true,
     });

--- a/src/shared/adapters/generic-api.adapter.spec.ts
+++ b/src/shared/adapters/generic-api.adapter.spec.ts
@@ -33,6 +33,13 @@ describe('GenericApiAdapter', () => {
 
       expect(listFn).toHaveBeenCalledTimes(1);
     });
+
+    it('listFn が reject した場合はエラーを伝播する', async () => {
+      const error = new Error('network error');
+      listFn.mockRejectedValue(error);
+
+      await expect(adapter.findAll()).rejects.toThrow('network error');
+    });
   });
 
   describe('findById()', () => {
@@ -51,6 +58,13 @@ describe('GenericApiAdapter', () => {
       await adapter.findById(99);
 
       expect(getFn).toHaveBeenCalledWith(99);
+    });
+
+    it('getFn が reject した場合はエラーを伝播する', async () => {
+      const error = new Error('not found');
+      getFn.mockRejectedValue(error);
+
+      await expect(adapter.findById(1)).rejects.toThrow('not found');
     });
   });
 
@@ -71,6 +85,15 @@ describe('GenericApiAdapter', () => {
       await adapter.create(body);
 
       expect(createFn).toHaveBeenCalledWith(body);
+    });
+
+    it('createFn が reject した場合はエラーを伝播する', async () => {
+      const error = new Error('create is not supported');
+      createFn.mockRejectedValue(error);
+
+      await expect(adapter.create({ name: 'test' })).rejects.toThrow(
+        'create is not supported',
+      );
     });
   });
 });

--- a/src/shared/adapters/generic-api.adapter.spec.ts
+++ b/src/shared/adapters/generic-api.adapter.spec.ts
@@ -1,0 +1,76 @@
+import { GenericApiAdapter } from './generic-api.adapter';
+
+describe('GenericApiAdapter', () => {
+  type Item = { id: number; name: string };
+  type CreateBody = { name: string };
+
+  let listFn: jest.Mock;
+  let getFn: jest.Mock;
+  let createFn: jest.Mock;
+  let adapter: GenericApiAdapter<Item, CreateBody>;
+
+  beforeEach(() => {
+    listFn = jest.fn();
+    getFn = jest.fn();
+    createFn = jest.fn();
+    adapter = new GenericApiAdapter(listFn, getFn, createFn);
+  });
+
+  describe('findAll()', () => {
+    it('listFn の data を返す', async () => {
+      const items: Item[] = [{ id: 1, name: 'Alice' }];
+      listFn.mockResolvedValue({ data: items });
+
+      const result = await adapter.findAll();
+
+      expect(result).toEqual(items);
+    });
+
+    it('listFn を1回呼び出す', async () => {
+      listFn.mockResolvedValue({ data: [] });
+
+      await adapter.findAll();
+
+      expect(listFn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('findById()', () => {
+    it('getFn の data を返す', async () => {
+      const item: Item = { id: 42, name: 'Bob' };
+      getFn.mockResolvedValue({ data: item });
+
+      const result = await adapter.findById(42);
+
+      expect(result).toEqual(item);
+    });
+
+    it('getFn に id を渡す', async () => {
+      getFn.mockResolvedValue({ data: { id: 99, name: 'Carol' } });
+
+      await adapter.findById(99);
+
+      expect(getFn).toHaveBeenCalledWith(99);
+    });
+  });
+
+  describe('create()', () => {
+    it('createFn の data を返す', async () => {
+      const item: Item = { id: 1, name: 'Dave' };
+      createFn.mockResolvedValue({ data: item });
+
+      const result = await adapter.create({ name: 'Dave' });
+
+      expect(result).toEqual(item);
+    });
+
+    it('createFn に body を渡す', async () => {
+      const body: CreateBody = { name: 'Eve' };
+      createFn.mockResolvedValue({ data: { id: 2, name: 'Eve' } });
+
+      await adapter.create(body);
+
+      expect(createFn).toHaveBeenCalledWith(body);
+    });
+  });
+});

--- a/src/shared/adapters/generic-api.adapter.ts
+++ b/src/shared/adapters/generic-api.adapter.ts
@@ -1,0 +1,42 @@
+/**
+ * バックエンド API の CRUD 操作を抽象化する汎用 Adapter クラス。
+ *
+ * - 生成コード（DefaultApi など）と Service 層の間に挟まることで、
+ *   バックエンドのメソッド名変更・引数変更の影響をこの層で吸収できる。
+ * - コンストラクタに関数を渡す構成のため、どの API クラスでも再利用可能。
+ * - Adapter 自体はビジネスロジックを持たない。型変換・フィルタリングは Service が担う。
+ *
+ * @example
+ * ```typescript
+ * // src/users/adapters/user-backend.adapter.ts
+ * @Injectable()
+ * export class UserBackendAdapter extends GenericApiAdapter<UserDto, UserDto> {
+ *   constructor(@Inject(DEFAULT_API) api: DefaultApi) {
+ *     super(
+ *       () => api.getUsers(),
+ *       (id) => api.getUserById({ id }),
+ *       (body) => api.createUser({ createUserDto: body }),
+ *     );
+ *   }
+ * }
+ * ```
+ */
+export class GenericApiAdapter<TItem, TCreate = unknown> {
+  constructor(
+    private readonly listFn: () => Promise<{ data: TItem[] }>,
+    private readonly getFn: (id: number) => Promise<{ data: TItem }>,
+    private readonly createFn: (body: TCreate) => Promise<{ data: TItem }>,
+  ) {}
+
+  findAll(): Promise<TItem[]> {
+    return this.listFn().then((r) => r.data);
+  }
+
+  findById(id: number): Promise<TItem> {
+    return this.getFn(id).then((r) => r.data);
+  }
+
+  create(body: TCreate): Promise<TItem> {
+    return this.createFn(body).then((r) => r.data);
+  }
+}

--- a/src/users/adapters/user-backend.adapter.ts
+++ b/src/users/adapters/user-backend.adapter.ts
@@ -1,0 +1,21 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { DefaultApi } from '../../generated/api';
+import { UserDto } from '../../generated/models';
+import { DEFAULT_API } from '../../shared/config/axios-client.provider';
+import { GenericApiAdapter } from '../../shared/adapters/generic-api.adapter';
+
+/**
+ * UsersModule 向けの Backend Adapter。
+ * DefaultApi のメソッドを GenericApiAdapter に渡すことで、
+ * 生成コードのメソッド名変更は UsersService に影響せずここで吸収される。
+ */
+@Injectable()
+export class UserBackendAdapter extends GenericApiAdapter<UserDto, UserDto> {
+  constructor(@Inject(DEFAULT_API) api: DefaultApi) {
+    super(
+      () => api.getUsers(),
+      (id) => api.getUserById({ id }),
+      (body) => api.createUser({ createUserDto: body }),
+    );
+  }
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { MulterModule } from '@nestjs/platform-express';
+import { UserBackendAdapter } from './adapters/user-backend.adapter';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 
@@ -19,6 +20,6 @@ import { UsersService } from './users.service';
     }),
   ],
   controllers: [UsersController],
-  providers: [UsersService],
+  providers: [UserBackendAdapter, UsersService],
 })
 export class UsersModule {}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,40 +1,37 @@
 // NOTE: このモジュールは BFF 実装パターンのリファレンス実装です。
 // 実際の機能追加時はこのパターンを参考に新モジュールを作成してください。
 import { HttpService } from '@nestjs/axios';
-import { Inject, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { plainToInstance } from 'class-transformer';
-import { DEFAULT_API } from '../shared/config/axios-client.provider';
-import { DefaultApi } from '../generated/api';
 import { UserDto } from '../generated/models';
 import { CreateUserRequest } from './dto/create-user.request';
 import { UserResponse } from './dto/user.response';
+import { UserBackendAdapter } from './adapters/user-backend.adapter';
 
 @Injectable()
 export class UsersService {
   constructor(
-    @Inject(DEFAULT_API) private readonly api: DefaultApi,
+    private readonly adapter: UserBackendAdapter,
     private readonly httpService: HttpService,
   ) {}
 
   // try-catch 不要。AxiosError は Global ExceptionFilter が処理する
   async findAll(): Promise<UserResponse[]> {
-    const { data } = await this.api.getUsers();
+    const data = await this.adapter.findAll();
     return plainToInstance(UserResponse, data, {
       excludeExtraneousValues: true,
     });
   }
 
   async findOne(id: number): Promise<UserResponse> {
-    const { data } = await this.api.getUserById({ id });
+    const data = await this.adapter.findById(id);
     return plainToInstance(UserResponse, data, {
       excludeExtraneousValues: true,
     });
   }
 
   async create(dto: CreateUserRequest): Promise<UserResponse> {
-    const { data } = await this.api.createUser({
-      createUserDto: dto as UserDto,
-    });
+    const data = await this.adapter.create(dto as UserDto);
     return plainToInstance(UserResponse, data, {
       excludeExtraneousValues: true,
     });


### PR DESCRIPTION
## 概要

学習ロードマップ **Lv2（Generic Adapter パターン）** の実装。
`UsersService` / `ProductsService` が生成コードを直接呼び出す構造に Adapter 層を挟み、
バックエンド変更の影響局所化とボイラープレート削減を実現する。

Closes #5

## 変更内容

### 構造の変化

```
変更前: Controller → Service → DefaultApi（生成コード）
変更後: Controller → Service → BackendAdapter → DefaultApi（生成コード）
```

### 新規ファイル

| ファイル | 役割 |
|---------|------|
| `src/shared/adapters/generic-api.adapter.ts` | CRUD を関数で受け取る汎用 Adapter クラス |
| `src/users/adapters/user-backend.adapter.ts` | UsersModule 用 Adapter |
| `src/products/adapters/product-backend.adapter.ts` | ProductsModule 用 Adapter |

### 型の流れ（型断絶なし）

```
DefaultApi.getUsers() → UserDto[]
  ↓ UserBackendAdapter.findAll()     ← Adapter は生成型をそのまま返す
UserDto[]
  ↓ UsersService.findAll()           ← plainToInstance はここで維持
UserResponse[]
```

Adapter が生成型（`UserDto`）を返すため `tsc` がバックエンド変更を3層貫通して検出できる。

### 学習ポイント

- `UsersService.uploadFile()` は `HttpService` を直接使用するため Adapter 対象外（変更なし）
- `ProductBackendAdapter` は `create` 未サポートをコメントで明示 → 将来 `ProductsApi` に差し替える際の拡張ポイント

## テスト

```bash
npm test  # 119 passed（+6: GenericApiAdapter の単体テスト）
```